### PR TITLE
Adding VS Live Share

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "donjayamanne.jupyter",
         "wholroyd.jinja",
         "bibhasdn.django-html",
-        "bibhasdn.django-snippets"
+        "bibhasdn.django-snippets",
+	"MS-vsliveshare.vsliveshare"
     ]
 }


### PR DESCRIPTION
This PR simply proposes adding the Visual Studio Live Share extension to this extension pack, since it has great support for Python collaborative development/remote pair programming.

// CC @DonJayamanne 