### PR TITLE
remove Jupyter extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This extension pack packages some of the most popular (and some of my favorite) 
 ## Extensions Included
 
 * [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) - Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, Data Science (with Jupyter), PySpark and more.  
-* [Jupyter](https://marketplace.visualstudio.com/items?itemName=donjayamanne.jupyter) - Data Science with Jupyter on Visual Studio Code.  
 * [MagicPython](https://marketplace.visualstudio.com/items?itemName=magicstack.MagicPython) - Syntax highlighter for cutting edge Python.   
 * [Jinja](https://marketplace.visualstudio.com/items?itemName=wholroyd.jinja) - Jinja template language support for Visual Studio Code.   
 * [Django](https://marketplace.visualstudio.com/items?itemName=batisteo.vscode-django) - Beautiful syntax and scoped snippets for perfectionists with deadlines.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     },
 	"keywords": [
 		"python",
-		"jupyter",
 		"django",
 		"debugger",
 		"unittest",
@@ -38,7 +37,6 @@
     "extensionDependencies": [ 
         "magicstack.MagicPython", 
         "ms-python.python",
-        "donjayamanne.jupyter",
         "wholroyd.jinja",
         "batisteo.vscode-django", 
       	"VisualStudioExptTeam.vscodeintellicode"


### PR DESCRIPTION
Remove Jupyter extension as it's no longer maintained and all its features are (or will be) included in Microsoft Python extension