### PR TITLE
Magic Python features made redundant by Microsoft Python extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This extension pack packages some of the most popular (and some of my favorite) 
 ## Extensions Included
 
 * [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) - Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, Data Science (with Jupyter), PySpark and more.  
-* [MagicPython](https://marketplace.visualstudio.com/items?itemName=magicstack.MagicPython) - Syntax highlighter for cutting edge Python.   
 * [Jinja](https://marketplace.visualstudio.com/items?itemName=wholroyd.jinja) - Jinja template language support for Visual Studio Code.   
 * [Django](https://marketplace.visualstudio.com/items?itemName=batisteo.vscode-django) - Beautiful syntax and scoped snippets for perfectionists with deadlines.
 * [Visual Studio IntelliCode](https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode) - Provides AI-assisted productivity features for Python developers in Visual Studio Code with insights based on understanding your code combined with machine learning..

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This extension pack packages some of the most popular (and some of my favorite) 
 * [Jinja](https://marketplace.visualstudio.com/items?itemName=wholroyd.jinja) - Jinja template language support for Visual Studio Code.   
 * [Django](https://marketplace.visualstudio.com/items?itemName=batisteo.vscode-django) - Beautiful syntax and scoped snippets for perfectionists with deadlines.
 * [Visual Studio IntelliCode](https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode) - Provides AI-assisted productivity features for Python developers in Visual Studio Code with insights based on understanding your code combined with machine learning..
+* [Python Docstring Generator](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) - Quickly insert Python comment blocks with contextually inferred parameters for classes and methods based on multiple, selectable template patterns.
 
 ## Want to see your extension added?
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python-extension-pack",
     "displayName": "Python Extension Pack",
     "description": "Popular Visual Studio Code extensions for Python",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "publisher": "donjayamanne",
 	"author": {
 		"name": "Don Jayamanne",
@@ -35,7 +35,7 @@
         "Extension Packs"
     ],
     "extensionDependencies": [
-        "magicstack.MagicPython",
+        "njpwerner.autodocstring",
         "ms-python.python",
         "wholroyd.jinja",
         "batisteo.vscode-django",


### PR DESCRIPTION
Magic Python conflicts with VS Code Python Language Server (interfering with code completion) and its features have been made redundant as VS Code syntax highlighting for Python is excellent upon installing Python extension.
Also, the [Python Docstring Generator](https://github.com/NilsJPWerner/autoDocstring) extension by @NilsJPWerner is an excellent addition to the standard Python extensions, since it enables quick, hygienic code commenting with inferred parameter comment blocks.
