### PR TITLE
Add AWS boto3 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This extension pack packages some of the most popular (and some of my favorite) 
 * [Python Docstring Generator](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) - Quickly insert Python comment blocks with contextually inferred parameters for classes and methods based on multiple, selectable template patterns.
 * [Python Indent](https://marketplace.visualstudio.com/items?itemName=KevinRose.vsc-python-indent) - Correct python indentation in Visual Studio Code.
 * [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) - Provides Jupyter notebook support for Python language, used for data science, scientific computing and machine learning.
+* [AWS boto3](https://marketplace.visualstudio.com/items?itemName=Boto3typed.boto3-ide) - Provides IntelliSense and type checking for [AWS boto3](https://aws.amazon.com/sdk-for-python/).
 
 ## Want to see your extension added?
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "wholroyd.jinja",
     "batisteo.vscode-django",
     "VisualStudioExptTeam.vscodeintellicode",
-	"KevinRose.vsc-python-indent",
-	"donjayamanne.python-environment-manager"
+    "KevinRose.vsc-python-indent",
+    "donjayamanne.python-environment-manager",
+    "Boto3typed.boto3-ide"
   ]
 }


### PR DESCRIPTION
Hello!

Thank you for this awesome extension pack, I have been using it for years already!

Some time ago I created [boto3-stubs](https://pypi.org/project/boto3-stubs/) package that provides code auto-complete and type checking for all `boto3` libraries. It became quite popular and has over 600 thousand downloads monthly.

I added a [AWS boto3 extension](https://marketplace.visualstudio.com/items?itemName=Boto3typed.boto3-ide) that helps you to install `boto3` auto-complete only for services you use. The extension by itself does nothing in the background, it is only activated when you run a command, so it should be safe to add.

Also, `boto3` is one of the most downloaded Python packages on PyPI, so I believe many Python developers might find it useful.

Please let me know if you think this extension can be included in your pack.

Regards, Vlad.

