### PR TITLE
Switch to better django extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.0
+
+- switch to better django extension
+
 ## 1.7.0
 
 - Add Python Indent

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This extension pack packages some of the most popular (and some of my favorite) 
 
 * [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) - Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, Data Science (with Jupyter), PySpark and more.
 * [Jinja](https://marketplace.visualstudio.com/items?itemName=wholroyd.jinja) - Jinja template language support for Visual Studio Code.
-* [Django](https://marketplace.visualstudio.com/items?itemName=batisteo.vscode-django) - Beautiful syntax and scoped snippets for perfectionists with deadlines.
+* [Django Support](https://marketplace.visualstudio.com/items?itemName=almahdi.code-django) - Best syntax highlighter and snippets for Django.
 * [Visual Studio IntelliCode](https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode) - Provides AI-assisted productivity features for Python developers in Visual Studio Code with insights based on understanding your code combined with machine learning..
 * [Python Environment Manager](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python-environment-manager) - Provides the ability to view and manage all of your Python environments & packages from a single place.
 * [Python Docstring Generator](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) - Quickly insert Python comment blocks with contextually inferred parameters for classes and methods based on multiple, selectable template patterns.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "python-extension-pack",
   "displayName": "Python Extension Pack",
   "description": "Popular Visual Studio Code extensions for Python",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "publisher": "donjayamanne",
   "author": {
     "name": "Don Jayamanne",
@@ -38,9 +38,9 @@
     "njpwerner.autodocstring",
     "ms-python.python",
     "wholroyd.jinja",
-    "batisteo.vscode-django",
+    "almahdi.code-django",
     "VisualStudioExptTeam.vscodeintellicode",
-	"KevinRose.vsc-python-indent",
-	"donjayamanne.python-environment-manager"
+    "KevinRose.vsc-python-indent",
+    "donjayamanne.python-environment-manager"
   ]
 }


### PR DESCRIPTION
The current [django extension](https://github.com/vscode-django/vscode-django) has many issues.

This [Django Support](https://marketplace.visualstudio.com/items?itemName=almahdi.code-django) extension has none while adding few other important features and is rated 5/5.

I have updated the changelog and version.

All you have to do is merge and publish.

Thank you.