### PR TITLE
Add DevDb to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This extension pack packages some of the most popular (and some of my favorite) 
 * [Python Docstring Generator](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) - Quickly insert Python comment blocks with contextually inferred parameters for classes and methods based on multiple, selectable template patterns.
 * [Python Indent](https://marketplace.visualstudio.com/items?itemName=KevinRose.vsc-python-indent) - Correct python indentation in Visual Studio Code.
 * [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) - Provides Jupyter notebook support for Python language, used for data science, scientific computing and machine learning.
+* [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) - View database records in your Python projects right inside VS Code
 
 ## Want to see your extension added?
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "wholroyd.jinja",
     "batisteo.vscode-django",
     "VisualStudioExptTeam.vscodeintellicode",
-	"KevinRose.vsc-python-indent",
-	"donjayamanne.python-environment-manager"
+    "KevinRose.vsc-python-indent",
+    "donjayamanne.python-environment-manager",
+    "damms005.devdb"
   ]
 }


### PR DESCRIPTION
Adds DevDb to avoid context-switching between VS Code and database client, as the data is loaded into the IDE view